### PR TITLE
Feature/video grid layout responsive

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,7 @@ import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 import { testYouTubeApi } from './demo/youtubeDemo'
-import { SearchInput } from './components/SearchInput'
-import { VideoCard } from './components/VideoCard'
+import { SearchInput, VideoGrid } from './components'
 
 function App() {
   const [count, setCount] = useState(0)
@@ -57,27 +56,50 @@ function App() {
         </div>
 
         <div style={{ marginBottom: '20px' }}>
-          <h3>VideoCardコンポーネント デモ</h3>
-          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: '16px', marginTop: '16px' }}>
-            <VideoCard
-              videoId="dQw4w9WgXcQ"
-              title="Rick Astley - Never Gonna Give You Up (Official Video)"
-              thumbnail="https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg"
-              duration="3:33"
-            />
-            <VideoCard
-              videoId="9bZkp7q19f0"
-              title="PSY - GANGNAM STYLE (강남스타일) M/V"
-              thumbnail="https://img.youtube.com/vi/9bZkp7q19f0/maxresdefault.jpg"
-              duration="4:12"
-            />
-            <VideoCard
-              videoId="kJQP7kiw5Fk"
-              title="Luis Fonsi - Despacito ft. Daddy Yankee"
-              thumbnail="https://img.youtube.com/vi/kJQP7kiw5Fk/maxresdefault.jpg"
-              duration="4:41"
-            />
-          </div>
+          <h3>VideoGrid コンポーネント デモ</h3>
+          <VideoGrid
+            videos={[
+              {
+                videoId: "dQw4w9WgXcQ",
+                title: "Rick Astley - Never Gonna Give You Up (Official Video)",
+                thumbnail: "https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg",
+                duration: "3:33"
+              },
+              {
+                videoId: "9bZkp7q19f0",
+                title: "PSY - GANGNAM STYLE (강남스타일) M/V",
+                thumbnail: "https://img.youtube.com/vi/9bZkp7q19f0/maxresdefault.jpg",
+                duration: "4:12"
+              },
+              {
+                videoId: "kJQP7kiw5Fk",
+                title: "Luis Fonsi - Despacito ft. Daddy Yankee",
+                thumbnail: "https://img.youtube.com/vi/kJQP7kiw5Fk/maxresdefault.jpg",
+                duration: "4:41"
+              },
+              {
+                videoId: "JGwWNGJdvx8",
+                title: "Ed Sheeran - Shape of You (Official Video)",
+                thumbnail: "https://img.youtube.com/vi/JGwWNGJdvx8/maxresdefault.jpg",
+                duration: "3:53"
+              },
+              {
+                videoId: "fJ9rUzIMcZQ",
+                title: "Queen - Bohemian Rhapsody (Official Video)",
+                thumbnail: "https://img.youtube.com/vi/fJ9rUzIMcZQ/maxresdefault.jpg",
+                duration: "5:55"
+              },
+              {
+                videoId: "YQHsXMglC9A",
+                title: "Adele - Hello (Official Music Video)",
+                thumbnail: "https://img.youtube.com/vi/YQHsXMglC9A/maxresdefault.jpg",
+                duration: "6:07"
+              }
+            ]}
+            columns={3}
+            gap={16}
+            maxRows={2}
+          />
         </div>
         
         <button 

--- a/frontend/src/components/VideoGrid.tsx
+++ b/frontend/src/components/VideoGrid.tsx
@@ -1,0 +1,65 @@
+import * as React from "react"
+import { VideoCard } from './VideoCard'
+import type { VideoCardProps } from './VideoCard'
+
+export interface VideoGridProps {
+  videos: VideoCardProps[]
+  columns?: 1 | 2 | 3 | 4
+  gap?: number
+  maxRows?: number
+  className?: string
+}
+
+const VideoGrid = React.forwardRef<HTMLDivElement, VideoGridProps>(
+  ({ videos, columns = 3, gap = 16, maxRows, className, ...props }, ref) => {
+    const displayVideos = React.useMemo(() => {
+      if (!maxRows) return videos
+      const maxItems = columns * maxRows
+      return videos.slice(0, maxItems)
+    }, [videos, columns, maxRows])
+
+    const getGridColumns = () => {
+      switch (columns) {
+        case 1:
+          return 'grid-cols-1'
+        case 2:
+          return 'grid-cols-1 sm:grid-cols-2'
+        case 3:
+          return 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
+        case 4:
+          return 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4'
+        default:
+          return 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
+      }
+    }
+
+    const getGapClass = () => {
+      if (gap <= 8) return 'gap-2'
+      if (gap <= 12) return 'gap-3'
+      if (gap <= 16) return 'gap-4'
+      if (gap <= 20) return 'gap-5'
+      if (gap <= 24) return 'gap-6'
+      return 'gap-8'
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={`grid ${getGridColumns()} ${getGapClass()} ${className || ""}`}
+        style={{ gap: `${gap}px` }}
+        {...props}
+      >
+        {displayVideos.map((video, index) => (
+          <VideoCard
+            key={`${video.videoId}-${index}`}
+            {...video}
+          />
+        ))}
+      </div>
+    )
+  }
+)
+
+VideoGrid.displayName = "VideoGrid"
+
+export { VideoGrid }

--- a/frontend/src/components/__tests__/VideoGrid.test.tsx
+++ b/frontend/src/components/__tests__/VideoGrid.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { VideoGrid } from '../VideoGrid'
+import type { VideoCardProps } from '../VideoCard'
+
+const mockVideos: VideoCardProps[] = [
+  {
+    videoId: "1",
+    title: "Test Video 1",
+    thumbnail: "https://example.com/thumb1.jpg",
+    duration: "3:33"
+  },
+  {
+    videoId: "2", 
+    title: "Test Video 2",
+    thumbnail: "https://example.com/thumb2.jpg",
+    duration: "4:12"
+  },
+  {
+    videoId: "3",
+    title: "Test Video 3", 
+    thumbnail: "https://example.com/thumb3.jpg",
+    duration: "2:45"
+  },
+  {
+    videoId: "4",
+    title: "Test Video 4",
+    thumbnail: "https://example.com/thumb4.jpg",
+    duration: "5:21"
+  },
+  {
+    videoId: "5",
+    title: "Test Video 5",
+    thumbnail: "https://example.com/thumb5.jpg",
+    duration: "1:58"
+  },
+  {
+    videoId: "6",
+    title: "Test Video 6",
+    thumbnail: "https://example.com/thumb6.jpg", 
+    duration: "6:12"
+  }
+]
+
+describe('VideoGrid', () => {
+  it('renders all videos when no maxRows is set', () => {
+    render(<VideoGrid videos={mockVideos} />)
+    
+    mockVideos.forEach(video => {
+      expect(screen.getByText(video.title)).toBeInTheDocument()
+    })
+  })
+
+  it('limits videos by maxRows when set', () => {
+    render(<VideoGrid videos={mockVideos} columns={2} maxRows={2} />)
+    
+    // Should show only 4 videos (2 columns × 2 rows)
+    expect(screen.getByText("Test Video 1")).toBeInTheDocument()
+    expect(screen.getByText("Test Video 2")).toBeInTheDocument()
+    expect(screen.getByText("Test Video 3")).toBeInTheDocument()
+    expect(screen.getByText("Test Video 4")).toBeInTheDocument()
+    expect(screen.queryByText("Test Video 5")).not.toBeInTheDocument()
+    expect(screen.queryByText("Test Video 6")).not.toBeInTheDocument()
+  })
+
+  it('applies correct CSS classes for column configuration', () => {
+    const { container } = render(<VideoGrid videos={mockVideos} columns={4} />)
+    const gridElement = container.firstChild as HTMLElement
+    
+    expect(gridElement).toHaveClass('grid')
+    expect(gridElement).toHaveClass('grid-cols-1')
+    expect(gridElement).toHaveClass('sm:grid-cols-2') 
+    expect(gridElement).toHaveClass('lg:grid-cols-3')
+    expect(gridElement).toHaveClass('xl:grid-cols-4')
+  })
+
+  it('applies correct gap classes', () => {
+    const { container } = render(<VideoGrid videos={mockVideos} gap={8} />)
+    const gridElement = container.firstChild as HTMLElement
+    
+    expect(gridElement).toHaveClass('gap-2')
+  })
+
+  it('applies custom className when provided', () => {
+    const { container } = render(<VideoGrid videos={mockVideos} className="custom-class" />)
+    const gridElement = container.firstChild as HTMLElement
+    
+    expect(gridElement).toHaveClass('custom-class')
+  })
+
+  it('renders empty grid when no videos provided', () => {
+    const { container } = render(<VideoGrid videos={[]} />)
+    const gridElement = container.firstChild as HTMLElement
+    
+    expect(gridElement).toHaveClass('grid')
+    expect(gridElement.children).toHaveLength(0)
+  })
+
+  it('handles single column layout correctly', () => {
+    const { container } = render(<VideoGrid videos={mockVideos} columns={1} />)
+    const gridElement = container.firstChild as HTMLElement
+    
+    expect(gridElement).toHaveClass('grid-cols-1')
+    expect(gridElement).not.toHaveClass('sm:grid-cols-2')
+  })
+
+  it('handles different gap sizes correctly', () => {
+    const testCases = [
+      { gap: 8, expectedClass: 'gap-2' },
+      { gap: 12, expectedClass: 'gap-3' },
+      { gap: 16, expectedClass: 'gap-4' },
+      { gap: 20, expectedClass: 'gap-5' },
+      { gap: 24, expectedClass: 'gap-6' },
+      { gap: 32, expectedClass: 'gap-8' }
+    ]
+
+    testCases.forEach(({ gap, expectedClass }) => {
+      const { container } = render(<VideoGrid videos={mockVideos} gap={gap} />)
+      const gridElement = container.firstChild as HTMLElement
+      expect(gridElement).toHaveClass(expectedClass)
+    })
+  })
+
+  it('maxRows calculation works correctly with different column counts', () => {
+    const { rerender } = render(<VideoGrid videos={mockVideos} columns={3} maxRows={1} />)
+    
+    // Should show 3 videos (3 columns × 1 row)
+    expect(screen.getByText("Test Video 1")).toBeInTheDocument()
+    expect(screen.getByText("Test Video 2")).toBeInTheDocument()
+    expect(screen.getByText("Test Video 3")).toBeInTheDocument()
+    expect(screen.queryByText("Test Video 4")).not.toBeInTheDocument()
+
+    rerender(<VideoGrid videos={mockVideos} columns={2} maxRows={2} />)
+    
+    // Should show 4 videos (2 columns × 2 rows)
+    expect(screen.getByText("Test Video 4")).toBeInTheDocument()
+    expect(screen.queryByText("Test Video 5")).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,4 +1,6 @@
 export { SearchInput } from './SearchInput'
 export { VideoCard } from './VideoCard'
+export { VideoGrid } from './VideoGrid'
 export type { SearchInputProps } from './SearchInput'
 export type { VideoCardProps } from './VideoCard'
+export type { VideoGridProps } from './VideoGrid'


### PR DESCRIPTION
## 概要

  GitHub Issue #7 の対応として、レスポンシブなVideoGridコンポーネントをCSS
  Gridで実装しました。1-4カラムの可変レイアウトと行数制限機能を提供します。

###  実装内容

  - レスポンシブ対応: 1-4カラムの自動調整（ブレークポイント: sm, lg, xl）
  - ギャップ設定: 8px-32pxの可変間隔
  - 行数制限: maxRowsプロパティで表示行数を制限
  - TypeScript完全対応: 型安全性とverbatimModuleSyntax対応
  - 包括的テスト: 9つのテストケースで全機能カバー

###  編集ファイル

  新規作成

  - frontend/src/components/VideoGrid.tsx - メインコンポーネント
  - frontend/src/components/__tests__/VideoGrid.test.tsx - テストスイート

  編集

  - frontend/src/components/index.ts - エクスポート追加
  - frontend/src/App.tsx - VideoGrid統合とデモ実装